### PR TITLE
Add getRouteName to mocked methods

### DIFF
--- a/app/code/community/Studioforty9/Recaptcha/Test/Model/Observer.php
+++ b/app/code/community/Studioforty9/Recaptcha/Test/Model/Observer.php
@@ -436,7 +436,7 @@ class Studioforty9_Recaptcha_Test_Model_Observer extends EcomDev_PHPUnit_Test_Ca
     {
         $request = $this->getMockBuilder('Zend_Controller_Request_Abstract')
             ->disableOriginalConstructor()
-            ->setMethods(array('setDispatched', 'isPost', 'getPost'))
+            ->setMethods(array('setDispatched', 'isPost', 'getPost', 'getRouteName'))
             ->getMock();
 
         // Expect getRouteName to be called


### PR DESCRIPTION
PHPUnit 5.7.7 complains that the method getRouteName doesn't exist. Adding it to the mocked methods array solves this.